### PR TITLE
Added file transfer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,16 @@ if(fooBar != null) // Make sure we pass a valid reference
 ```
 
 ### Exceptions
-There are two exceptions:
+There are three exceptions:
 - QueryProtocolException
 
     Only occurs when the server sends an invalid response, meaning the server violates the protocol specifications.
 - QueryException
 
     Occurs every time the server responds with an error code that is not `0`. It holds the error information, for example the error code, error message and - if applicatable - the missing permission id for the operation.
+- FileTransferException
+
+    Occurs when there was an error uploading or downloading a file.
 
 Note that exceptions are also thrown when a network problem occurs. Just like a normal TcpClient.
 

--- a/src/TeamSpeak3QueryApi/FileTransferClient.cs
+++ b/src/TeamSpeak3QueryApi/FileTransferClient.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TeamSpeak3QueryApi.Net
+{
+    internal class FileTransferClient
+    {
+        private readonly string _host;
+        private static int _currentFileTransferId = 1;
+
+        public FileTransferClient(string hostName)
+        {
+            _host = hostName;
+        }
+
+        public int GetFileTransferId()
+        {
+            return _currentFileTransferId++;
+        }
+
+        public async Task SendFile(byte[] data, int port, string key)
+        {
+            using var client = new TcpClient();
+            await client.ConnectAsync(_host, port).ConfigureAwait(false);
+            var ns = client.GetStream();
+
+            // Send key
+            var keyBytes = Encoding.ASCII.GetBytes(key);
+            await ns.WriteAsync(keyBytes, 0, keyBytes.Length).ConfigureAwait(false);
+            ns.Flush();
+
+            // Send data
+            await ns.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+        }
+
+        public async Task SendFile(Stream dataStream, long size, int port, string key)
+        {
+            using var client = new TcpClient();
+            await client.ConnectAsync(_host, port).ConfigureAwait(false);
+            var ns = client.GetStream();
+
+            // Send key
+            var keyBytes = Encoding.ASCII.GetBytes(key);
+            ns.Write(keyBytes, 0, keyBytes.Length);
+            ns.Flush();
+
+            // Send data
+            var bytesRemaining = size;
+            var buffer = new byte[4096];
+            do
+            {
+                // Read from source. Cast is safe because buffer.Length is Int32.
+                var bytesRead = await dataStream.ReadAsync(buffer, 0, (int) Math.Min(buffer.Length, bytesRemaining)).ConfigureAwait(false);
+
+                // Write into network stream
+                await ns.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
+
+                bytesRemaining -= bytesRead;
+            } while (bytesRemaining > 0);
+        }
+
+        public async Task<byte[]> ReceiveFile(int size, int port, string key)
+        {
+            using var client = new TcpClient();
+            await client.ConnectAsync(_host, port).ConfigureAwait(false);
+            var ns = client.GetStream();
+
+            // Send key
+            var keyBytes = Encoding.ASCII.GetBytes(key);
+            ns.Write(keyBytes, 0, keyBytes.Length);
+            ns.Flush();
+
+            // Receive data
+            var result = new byte[size];
+            var bytesRead = 0;
+            do
+            {
+                bytesRead += await ns.ReadAsync(result, bytesRead, size - bytesRead).ConfigureAwait(false);
+            }
+            while (bytesRead < size);
+
+            return result;
+        }
+    }
+}

--- a/src/TeamSpeak3QueryApi/FileTransferClient.cs
+++ b/src/TeamSpeak3QueryApi/FileTransferClient.cs
@@ -50,7 +50,7 @@ namespace TeamSpeak3QueryApi.Net
             await dataStream.CopyToAsync(ns).ConfigureAwait(false);
         }
 
-        public async Task<MemoryStream> ReceiveFile(int size, int port, string key)
+        public async Task<Stream> ReceiveFile(int size, int port, string key)
         {
             using var client = new TcpClient();
             await client.ConnectAsync(_host, port).ConfigureAwait(false);

--- a/src/TeamSpeak3QueryApi/FileTransferClient.cs
+++ b/src/TeamSpeak3QueryApi/FileTransferClient.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;
@@ -25,62 +24,47 @@ namespace TeamSpeak3QueryApi.Net
         {
             using var client = new TcpClient();
             await client.ConnectAsync(_host, port).ConfigureAwait(false);
-            var ns = client.GetStream();
+            using var ns = client.GetStream();
 
             // Send key
             var keyBytes = Encoding.ASCII.GetBytes(key);
             await ns.WriteAsync(keyBytes, 0, keyBytes.Length).ConfigureAwait(false);
-            ns.Flush();
+            await ns.FlushAsync().ConfigureAwait(false);
 
             // Send data
             await ns.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
         }
 
-        public async Task SendFile(Stream dataStream, long size, int port, string key)
+        public async Task SendFile(Stream dataStream, int port, string key)
         {
             using var client = new TcpClient();
             await client.ConnectAsync(_host, port).ConfigureAwait(false);
-            var ns = client.GetStream();
+            using var ns = client.GetStream();
 
             // Send key
             var keyBytes = Encoding.ASCII.GetBytes(key);
-            ns.Write(keyBytes, 0, keyBytes.Length);
-            ns.Flush();
+            await ns.WriteAsync(keyBytes, 0, keyBytes.Length).ConfigureAwait(false);
+            await ns.FlushAsync().ConfigureAwait(false);
 
             // Send data
-            var bytesRemaining = size;
-            var buffer = new byte[4096];
-            do
-            {
-                // Read from source. Cast is safe because buffer.Length is Int32.
-                var bytesRead = await dataStream.ReadAsync(buffer, 0, (int) Math.Min(buffer.Length, bytesRemaining)).ConfigureAwait(false);
-
-                // Write into network stream
-                await ns.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
-
-                bytesRemaining -= bytesRead;
-            } while (bytesRemaining > 0);
+            await dataStream.CopyToAsync(ns).ConfigureAwait(false);
         }
 
-        public async Task<byte[]> ReceiveFile(int size, int port, string key)
+        public async Task<MemoryStream> ReceiveFile(int size, int port, string key)
         {
             using var client = new TcpClient();
             await client.ConnectAsync(_host, port).ConfigureAwait(false);
-            var ns = client.GetStream();
+            using var ns = client.GetStream();
 
             // Send key
             var keyBytes = Encoding.ASCII.GetBytes(key);
-            ns.Write(keyBytes, 0, keyBytes.Length);
-            ns.Flush();
+            await ns.WriteAsync(keyBytes, 0, keyBytes.Length).ConfigureAwait(false);
+            await ns.FlushAsync().ConfigureAwait(false);
 
             // Receive data
-            var result = new byte[size];
-            var bytesRead = 0;
-            do
-            {
-                bytesRead += await ns.ReadAsync(result, bytesRead, size - bytesRead).ConfigureAwait(false);
-            }
-            while (bytesRead < size);
+            var result = new MemoryStream(size);
+            await ns.CopyToAsync(result).ConfigureAwait(false);
+            result.Position = 0;
 
             return result;
         }

--- a/src/TeamSpeak3QueryApi/FileTransferException.cs
+++ b/src/TeamSpeak3QueryApi/FileTransferException.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TeamSpeak3QueryApi.Net
+{
+    /// <summary>Represents errors that occur during file transfers.</summary>
+    [Serializable]
+    public class FileTransferException : Exception
+    {
+        /// <summary>Initializes a new instance of the <see cref="T:TeamSpeak3QueryApi.Net.FileTransferException"/> class with a specified error message.</summary>
+        /// <param name="message">The message that describes the error.</param>
+        public FileTransferException(string message)
+            : this(message, null)
+        { }
+
+        /// <summary>Initializes a new instance of the <see cref="T:TeamSpeak3QueryApi.Net.FileTransferException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.</summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (<see langword="langword">Nothing</see> in Visual Basic) if no inner exception is specified.</param>
+        public FileTransferException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+    }
+}

--- a/src/TeamSpeak3QueryApi/ParameterValue.cs
+++ b/src/TeamSpeak3QueryApi/ParameterValue.cs
@@ -41,6 +41,10 @@ namespace TeamSpeak3QueryApi.Net
         /// <param name="fromParameter">The value</param>
         public static implicit operator ParameterValue(int fromParameter) => new ParameterValue(fromParameter.ToString(CultureInfo.CurrentCulture));
 
+        /// <summary>Creates a new parameter value using a <see cref="T:System.Int64"/> as value.</summary>
+        /// <param name="fromParameter">The value</param>
+        public static implicit operator ParameterValue(long fromParameter) => new ParameterValue(fromParameter.ToString(CultureInfo.CurrentCulture));
+
         /// <summary>Creates a new parameter value using a <see cref="T:System.Int32"/> as value.</summary>
         /// <param name="fromParameter">The value</param>
         public static implicit operator ParameterValue(bool fromParameter) => new ParameterValue(fromParameter ? "1" : "0");

--- a/src/TeamSpeak3QueryApi/Specialized/DataProxy.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/DataProxy.cs
@@ -24,7 +24,8 @@ namespace TeamSpeak3QueryApi.Net.Specialized
             [typeof(MessageTarget)] = new EnumTypeCaster<MessageTarget>(),
             [typeof(short)] = new Int16TypeCaster(),
             [typeof(Codec)] = new EnumTypeCaster<Codec>(),
-            [typeof(IReadOnlyList<int>)] = new ReadonlyListIntCaster()
+            [typeof(IReadOnlyList<int>)] = new ReadonlyListIntCaster(),
+            [typeof(double)] = new DoubleTypeCaster()
         };
 
         public static IReadOnlyList<T> SerializeGeneric<T>(IReadOnlyList<QueryResponseDictionary> response)

--- a/src/TeamSpeak3QueryApi/Specialized/ITypeCaster.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/ITypeCaster.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace TeamSpeak3QueryApi.Net.Specialized
@@ -123,6 +124,18 @@ namespace TeamSpeak3QueryApi.Net.Specialized
                 return null;
             
             return sourceStr.Split(',').Select(int.Parse).ToList();
+        }
+    }
+
+    class DoubleTypeCaster : ITypeCaster
+    {
+        public virtual dynamic Cast(object source)
+        {
+            if (source == null)
+                return 0.0;
+            if (source is double)
+                return (double)source;
+            return double.Parse(source.ToString(), CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/TeamSpeak3QueryApi/Specialized/Responses/GetCurrentFileTransfer.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/Responses/GetCurrentFileTransfer.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TeamSpeak3QueryApi.Net.Specialized.Responses
+{
+    public class GetCurrentFileTransfer : Response
+    {
+        [QuerySerialize("clid")]
+        public int ClientId;
+
+        [QuerySerialize("path")]
+        public string DirPath;
+
+        [QuerySerialize("name")]
+        public string FileName;
+
+        [QuerySerialize("size")]
+        public long Size;
+
+        [QuerySerialize("sizedone")]
+        public long SizeDone;
+
+        [QuerySerialize("clientftfid")]
+        public int ClientFileTransferId;
+
+        [QuerySerialize("serverftfid")]
+        public int ServerFileTransferId;
+
+        [QuerySerialize("sender")]
+        public bool ServerIsSender;
+
+        [QuerySerialize("current_speed")]
+        public double CurrentSpeed;
+
+        [QuerySerialize("average_speed")]
+        public double AverageSpeed;
+
+        [QuerySerialize("runtime")]
+        public int Runtime;
+    }
+}

--- a/src/TeamSpeak3QueryApi/Specialized/Responses/GetFileInfo.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/Responses/GetFileInfo.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TeamSpeak3QueryApi.Net.Specialized.Responses
+{
+    public class GetFileInfo : Response
+    {
+        [QuerySerialize("name")]
+        public string FilePath;
+
+        [QuerySerialize("size")]
+        public long Size;
+
+        [QuerySerialize("datetime")]
+        public DateTime Modified;
+    }
+}

--- a/src/TeamSpeak3QueryApi/Specialized/Responses/GetFiles.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/Responses/GetFiles.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TeamSpeak3QueryApi.Net.Specialized.Responses
+{
+    public class GetFiles : Response
+    {
+        [QuerySerialize("name")]
+        public string Name;
+
+        [QuerySerialize("size")]
+        public long Size;
+
+        [QuerySerialize("datetime")]
+        public DateTime Modified;
+
+        [QuerySerialize("type")]
+        public bool IsFile;
+    }
+}

--- a/src/TeamSpeak3QueryApi/Specialized/Responses/InitDownload.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/Responses/InitDownload.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TeamSpeak3QueryApi.Net.Specialized.Responses
+{
+    public class InitDownload : Response
+    {
+        [QuerySerialize("clientftfid")]
+        public int ClientFileTransferId;
+
+        [QuerySerialize("serverftfid")]
+        public int ServerFileTransferId;
+
+        [QuerySerialize("ftkey")]
+        public string FileTransferKey;
+
+        [QuerySerialize("port")]
+        public int Port;
+
+        [QuerySerialize("size")]
+        public long Size;
+    }
+}

--- a/src/TeamSpeak3QueryApi/Specialized/Responses/InitUpload.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/Responses/InitUpload.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TeamSpeak3QueryApi.Net.Specialized.Responses
+{
+    public class InitUpload : Response
+    {
+        [QuerySerialize("clientftfid")]
+        public int ClientFileTransferId;
+
+        [QuerySerialize("serverftfid")]
+        public int ServerFileTransferId;
+
+        [QuerySerialize("ftkey")]
+        public string FileTransferKey;
+
+        [QuerySerialize("port")]
+        public int Port;
+    }
+}

--- a/src/TeamSpeak3QueryApi/Specialized/TeamSpeakClient.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/TeamSpeakClient.cs
@@ -836,9 +836,9 @@ namespace TeamSpeak3QueryApi.Net.Specialized
 
         #region DownloadFile
 
-        public Task<MemoryStream> DownloadFile(int channelId, string filePath) => DownloadFile(channelId, string.Empty, filePath);
+        public Task<Stream> DownloadFile(int channelId, string filePath) => DownloadFile(channelId, string.Empty, filePath);
 
-        public async Task<MemoryStream> DownloadFile(int channelId, string channelPassword, string filePath)
+        public async Task<Stream> DownloadFile(int channelId, string channelPassword, string filePath)
         {
             var res = await Client.Send("ftinitdownload",
                 new Parameter("clientftfid", _fileTransferClient.GetFileTransferId()),

--- a/src/TeamSpeak3QueryApi/Specialized/TeamSpeakClient.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/TeamSpeakClient.cs
@@ -777,7 +777,7 @@ namespace TeamSpeak3QueryApi.Net.Specialized
 
             var parsedRes = DataProxy.SerializeGeneric<InitUpload>(res).First();
 
-            await _fileTransferClient.SendFile(dataStream, size, parsedRes.Port, parsedRes.FileTransferKey).ConfigureAwait(false);
+            await _fileTransferClient.SendFile(dataStream, parsedRes.Port, parsedRes.FileTransferKey).ConfigureAwait(false);
 
             if (verify)
             {
@@ -836,9 +836,9 @@ namespace TeamSpeak3QueryApi.Net.Specialized
 
         #region DownloadFile
 
-        public Task<byte[]> DownloadFile(int channelId, string filePath) => DownloadFile(channelId, string.Empty, filePath);
+        public Task<MemoryStream> DownloadFile(int channelId, string filePath) => DownloadFile(channelId, string.Empty, filePath);
 
-        public async Task<byte[]> DownloadFile(int channelId, string channelPassword, string filePath)
+        public async Task<MemoryStream> DownloadFile(int channelId, string channelPassword, string filePath)
         {
             var res = await Client.Send("ftinitdownload",
                 new Parameter("clientftfid", _fileTransferClient.GetFileTransferId()),

--- a/src/TeamSpeak3QueryApi/Specialized/TeamSpeakClient.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/TeamSpeakClient.cs
@@ -792,7 +792,7 @@ namespace TeamSpeak3QueryApi.Net.Specialized
             var intervalMillis = 100;
             var timeoutMillis = 3000;
             var currentTimeoutMillis = intervalMillis * -1;
-            
+
             while (true)
             {
                 var transfers = await GetCurrentFileTransfers();
@@ -835,6 +835,8 @@ namespace TeamSpeak3QueryApi.Net.Specialized
         #endregion
 
         #region DownloadFile
+
+        public Task<byte[]> DownloadFile(int channelId, string filePath) => DownloadFile(channelId, string.Empty, filePath);
 
         public async Task<byte[]> DownloadFile(int channelId, string channelPassword, string filePath)
         {


### PR DESCRIPTION
Added implementations for the following API commands:
- CreateDirectory (ftcreatedir): Creates a directory in a channel.
- DeleteFile (ftdeletefile): Deletes one or multiple files.
- GetFileInfo (ftgetfileinfo): Gets information about a file.
- GetFileList (ftgetfilelist): Gets information about files and directories in a directory.
- MoveFile (ftrenamefile): Moves (or renames) a file. Can also be used to move the file into a different channel.
- UploadFile (ftinitupload): Uploads a file.
- DownloadFile (ftinitdownload): Downloads a file.
- GetCurrentFileTransfers (ftlist): Gets information about active file transfers
- StopFileTransfer (ftstop): Stops a file transfer (Private, because file transfers are handled by the TeamSpeakClient).

FileTransfer procedure:
- TeamSpeakClient initializes uploads / downloads
- When successful, the client gets a FT key and the FT port by the query
- FileTransferClient connects to the FT interface and sends the FT key to the server
- FileTransferClient sends / receives the data