### PR TITLE
Added keep alive logic for the QueryClient and TeamSpeakClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Using the rich client, you can connect to a TeamSpeak Query server like this:
 ### Connect and Login
 
 ```C#
-var rc = new TeamSpeakClient(host, port); // Create rich client instance
+var rc = new TeamSpeakClient(host, port); // Create rich client instance, optionally use the internal 'keep-alive' logic to keep the client from disconnecting by passing true here.
 await rc.Connect(); // connect to the server
 await rc.Login(user, password); // login to do some stuff that requires permission
 await rc.UseServer(1); // Use the server with id '1'

--- a/src/TeamSpeak3QueryApi/Specialized/TeamSpeakClient.cs
+++ b/src/TeamSpeak3QueryApi/Specialized/TeamSpeakClient.cs
@@ -69,6 +69,10 @@ namespace TeamSpeak3QueryApi.Net.Specialized
                 {
                     await WhoAmI(); //Simple mindless task
                 }
+                if(TimeSpan.FromMilliseconds(Client.Idle.ElapsedMilliseconds).TotalMinutes > 1)
+                {
+                    await Task.Delay((int)TimeSpan.FromMinutes(1).TotalMilliseconds); //May as well wait 1 minute, since we're not close.
+                }
             }
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Like you say here https://github.com/nikeee/TeamSpeak3QueryAPI/issues/65 I think this should do the trick nicely, I can't be sure that the queue will process, it'll fire every 5 minutes, I don't like the loop there all that much, but I can't think of a better way to do it without upping the .NET standard so we could use Timers on events instead.

What do you think?